### PR TITLE
restoring code to remove trailing backslashes

### DIFF
--- a/tests/linkchecker.py
+++ b/tests/linkchecker.py
@@ -10,8 +10,8 @@ default_data_folder = '/home/echo/jetscape/JETSCAPE.github.io/data'
 def check_url(url, file):
     try: 
         # delete trailing backslashes
-        # while url[-1] == '\\':
-            # url = url[:-1]
+        while url[-1] == '\\':
+            url = url[:-1]
 
         # replace any backslash with forward slash
         url = url.replace('\\', '/')


### PR DESCRIPTION
Restoring these lines in the check_url function should fix that one remaining broken link. 

In the publications.json file, the link that is being parsed begins with http: and ends with the closing quotation mark:

`\"doi:http://dx.doi.org/10.17632/dhnmtfpz9k.1\" `

The backslash before the closing quotation mark is intended as an escape character because that closing quotation mark is meant to be part of the text, not to indicate the end of the string.  But, the function looking for URLs builds the URLs starting with http and ending at the closing quotation mark.  So, if the URL is located in a text string (as it is in this one case), that backslash ends up wrongly being included in the URL.  Those two commented lines in the check_url function account for this possibility and handle it.

`while url[-1] == '\\':`
`     url = url[:-1]`
